### PR TITLE
Fix setup docs for connect

### DIFF
--- a/source/apollo-server/setup.md
+++ b/source/apollo-server/setup.md
@@ -76,6 +76,7 @@ The following code snippet shows how to use Apollo Server with Connect:
 import connect from 'connect';
 import bodyParser from 'body-parser';
 import { apolloConnect } from 'apollo-server';
+import http from 'http';
 
 const PORT = 3000;
 
@@ -84,7 +85,7 @@ var app = connect();
 app.use('/graphql', bodyParser.json());
 app.use('/graphql', apolloConnect({ schema: myGraphQLSchema }));
 
-app.listen(PORT);
+http.createServer(app).listen(PORT);
 ```
 
 The `options` passed to `apolloConnect` are the same as those passed to `apolloExpress`.

--- a/source/apollo-server/setup.md
+++ b/source/apollo-server/setup.md
@@ -73,7 +73,7 @@ app.listen(PORT);
 The following code snippet shows how to use Apollo Server with Connect:
 
 ```js
-import connect from 'express';
+import connect from 'connect';
 import bodyParser from 'body-parser';
 import { apolloConnect } from 'apollo-server';
 
@@ -81,7 +81,8 @@ const PORT = 3000;
 
 var app = connect();
 
-app.use('/graphql', bodyParser.json(), apolloConnect({ schema: myGraphQLSchema }));
+app.use('/graphql', bodyParser.json());
+app.use('/graphql', apolloConnect({ schema: myGraphQLSchema }));
 
 app.listen(PORT);
 ```


### PR DESCRIPTION
Noticed the docs for connect were wrong:

1. The example was actually importing express, not connect
2. Connect's `use` method only supports 2 arguments
3. `app.listen` isn't available in connect, so use the http package to create a server (ripped from Connect's own docs)