### PR TITLE
Add graphql to the `npm install` command

### DIFF
--- a/source/apollo-server/index.md
+++ b/source/apollo-server/index.md
@@ -11,7 +11,7 @@ You can use Apollo Server with all popular JavaScript web servers, including Exp
 Install it with:
 
 ```txt
-npm install apollo-server
+npm install apollo-server graphql
 ```
 
 The following features distinguish Apollo Server from [express-graphql](https://github.com/graphql/express-graphql), Facebook's reference HTTP server implementation:


### PR DESCRIPTION
Some people aren't familiar with peer deps and are surprised / puzzled by `WARN apollo-server@0.3.2 requires a peer of graphql@^0.6.1 || ^0.7.0 but none was installed.`, or in the below case, think that it's an error and ask for help. 

Perhaps we should either make graphql a normal dependency or add it to the recommended install command here and in the README? 

![image](https://cloud.githubusercontent.com/assets/251288/19227790/6f97c4d6-8e8c-11e6-84e8-09b56121aff7.png)
