### PR TITLE
Documented the use of a GraphQLScalarType instance in resolvers

### DIFF
--- a/source/graphql-tools/scalars.md
+++ b/source/graphql-tools/scalars.md
@@ -12,17 +12,13 @@ To define a custom scalar you simply add it to the schema string with the follow
 scalar MyCustomScalar
 ```
 
-Afterwards, you have two options to define the behavior of your `MyCustomScalar` custom scalar:
-1. [Pass an instance of the `GraphQLScalarType` class](#GraphQLScalarType-instance) in the [resolver map](/tools/graphql-tools/resolvers.html#Resolver-map).
-2. [Define a custom object](#Custom-object) which will resolve your custom scalar type and use this object in the [resolver map](/tools/graphql-tools/resolvers.html#Resolver-map).
+Afterwards, you have to define the behavior of your `MyCustomScalar` custom scalar by passing an instance of the [`GraphQLScalarType`](http://graphql.org/graphql-js/type/#graphqlscalartype) class in the [resolver map](/tools/graphql-tools/resolvers.html#Resolver-map). This instance can be defined in a [dependency package](#Using-a-package) or [in your own code](#Own-GraphQLScalarType-instance).
+
+For more information about GraphQL's type system, please refer to the [official documentation](http://graphql.org/graphql-js/type/) or to the [Learning GraphQL](https://github.com/mugli/learning-graphql/blob/master/7.%20Deep%20Dive%20into%20GraphQL%20Type%20System.md) tutorial.
 
 Note that [Apollo Client does not currently have a way to automatically interpret custom scalars](https://github.com/apollostack/apollo-client/issues/585), so there's no way to automatically reverse the serialization on the client.
 
-## GraphQLScalarType instance
-
-If you choose this option, then the [`GraphQLScalarType`](http://graphql.org/graphql-js/type/#graphqlscalartype) instance you pass in the resolver map can be defined in a [dependency package](#Using-a-package) or [in your own code](#Own-GraphQLScalarType-instance).
-
-### Using a package
+## Using a package
 
 Here, we'll take the [graphql-type-json](https://github.com/taion/graphql-type-json) package as an example to demonstrate what can be done. This npm package defines a JSON GraphQL scalar type.
 
@@ -60,7 +56,7 @@ const jsSchema = makeExecutableSchema({ typeDefs: schemaString, resolvers: resol
 
 Remark : `GraphQLJSON` is a [`GraphQLScalarType`](http://graphql.org/graphql-js/type/#graphqlscalartype) instance.
 
-### Own `GraphQLScalarType` instance
+## Own `GraphQLScalarType` instance
 
 If needed, you can define your own [GraphQLScalarType](http://graphql.org/graphql-js/type/#graphqlscalartype) instance. This can be done the following way :
 
@@ -68,31 +64,25 @@ If needed, you can define your own [GraphQLScalarType](http://graphql.org/graphq
 import { GraphQLScalarType } from 'graphql';
 import { makeExecutableSchema } from 'graphql-tools';
 
-function mySerialize(value) {
-  let result;
-  // Implement your own behavior here by setting the 'result' variable
-  return result;
-}
-
-function myParseValue(value) {
-  let result;
-  // Implement your own behavior here by setting the 'result' variable
-  return result;
-}
-
-function myParseLiteral(ast) {
-  switch (ast.kind) {
-    // Implement your own behavior here by returning what suits your needs
-    // depending on ast.kind
-  }
-}
-
 const myCustomScalarType = new GraphQLScalarType({
   name: 'MyCustomScalar',
   description: 'Description of my custom scalar type',
-  serialize: mySerialize,
-  parseValue: myParseValue,
-  parseLiteral: myParseLiteral
+  serialize(value) {
+    let result;
+    // Implement your own behavior here by setting the 'result' variable
+    return result;
+  },
+  parseValue(value) {
+    let result;
+    // Implement your own behavior here by setting the 'result' variable
+    return result;
+  },
+  parseLiteral(ast) {
+    switch (ast.kind) {
+      // Implement your own behavior here by returning what suits your needs
+      // depending on ast.kind
+    }
+  }
 });
 
 const schemaString = `
@@ -116,18 +106,9 @@ const resolverFunctions = {
 const jsSchema = makeExecutableSchema({ typeDefs: schemaString, resolvers: resolveFunctions });
 ```
 
+## Examples
 
-## Custom object
-
-If you choose this option, you need to define the behavior of the scalar by supplying three functions:
-
-1. `__serialize`: How the value should be serialized as JSON when sent to the client in the query result.
-2. `__parseValue`: How the value should be parsed from JSON when received from the client in the form of query variables.
-3. `__parseLiteral`: How the value should be parsed from the query AST when received from the client as an inline argument in the query.
-
-These are the same as the methods you would use with GraphQL.js directly, but in `graphql-tools` they are prefixed with a double underscore to differentiate from field names.
-
-Let's look at a couple of examples to demonstrate how a custom scalar type can be defined using a custom object.
+Let's look at a couple of examples to demonstrate how a custom scalar type can be defined.
 
 ### Date as a scalar
 
@@ -146,23 +127,26 @@ type MyType {
 Next, the resolver:
 
 ```js
+import { GraphQLScalarType } from 'graphql';
 import { Kind } from 'graphql/language';
 
 const resolverMap = {
-  Date: {
-    __parseValue(value) {
+  Date: new GraphQLScalarType({
+    name: 'Date',
+    description: 'Date custom scalar type',
+    parseValue(value) {
       return new Date(value); // value from the client
     },
-    __serialize(value) {
+    serialize(value) {
       return value.getTime(); // value sent to the client
     },
-    __parseLiteral(ast) {
+    parseLiteral(ast) {
       if (ast.kind === Kind.INT) {
         return parseInt(ast.value, 10); // ast value is always in string format
       }
       return null;
     },
-  },
+  }),
 };
 ```
 
@@ -181,72 +165,25 @@ type MyType {
 Next, the resolver:
 
 ```js
+import { GraphQLScalarType } from 'graphql';
 import { Kind } from 'graphql/language';
-
-Odd: {
-  __serialize: oddValue,
-  __parseValue: oddValue,
-  __parseLiteral(ast) {
-    if (ast.kind === Kind.INT) {
-      return oddValue(parseInt(ast.value, 10));
-    }
-    return null;
-  }
-}
 
 function oddValue(value) {
   return value % 2 === 1 ? value : null;
 }
-```
 
-### JSON as a scalar
-
-While we usually want to define a schema for our data, in some cases it makes sense to store unstructured objects in the database and not define a GraphQL schema for it. JSON is a commonly used format for storing such objects. In GraphQL, we can define a custom scalar type to serialize and parse JSON:
-
-
-```js
-scalar JSON
-
-type MyType {
-   jsonField: JSON
-}
-```
-
-And the implementation of the resolver:
-
-```js
-import { Kind } from 'graphql/language';
-
-function parseJSONLiteral(ast) {
-  switch (ast.kind) {
-    case Kind.STRING:
-    case Kind.BOOLEAN:
-      return ast.value;
-    case Kind.INT:
-    case Kind.FLOAT:
-      return parseFloat(ast.value);
-    case Kind.OBJECT: {
-      const value = Object.create(null);
-      ast.fields.forEach(field => {
-        value[field.name.value] = parseJSONLiteral(field.value);
-      });
-
-      return value;
-    }
-    case Kind.LIST:
-      return ast.values.map(parseJSONLiteral);
-    default:
+const resolverMap = {
+  Odd: new GraphQLScalarType({
+    name: 'Odd',
+    description: 'Odd custom scalar type',
+    parseValue: oddValue,
+    serialize: oddValue,
+    parseLiteral(ast) {
+      if (ast.kind === Kind.INT) {
+        return oddValue(parseInt(ast.value, 10));
+      }
       return null;
-  }
-}
-
-const resolvers =
-  JSON: {
-    __parseLiteral: parseJSONLiteral,
-    __serialize: value => value,
-    __parseValue: value => value,
-  },
+    },
+  }),
 };
 ```
-
-For more information please refer to the [official documentation](http://graphql.org/graphql-js/type/) or to the [Learning GraphQL](https://github.com/mugli/learning-graphql/blob/master/7.%20Deep%20Dive%20into%20GraphQL%20Type%20System.md) tutorial.


### PR DESCRIPTION
This PR adds documentation about passing a GraphQLScalarType through resolvers. See https://github.com/apollostack/graphql-tools/issues/176 (issue) and https://github.com/apollostack/graphql-tools/pull/189 (PR)