### PR TITLE
Document that koa GraphQLConfig functions take ctx

### DIFF
--- a/tools/graphql-server/setup.md
+++ b/tools/graphql-server/setup.md
@@ -152,3 +152,14 @@ app.use(router.routes());
 app.use(router.allowedMethods());
 app.listen(PORT);
 ```
+
+`graphqlOptions` can also be a callback that returns a GraphQLOptions or returns a promise that resolves to GraphQLOptions. This function takes a koa 2 `ctx` as its input.
+
+```js
+router.post('/graphql', graphqlKoa((ctx) => {
+  return { 
+    schema: myGraphQLSchema,
+    context: { userId: ctx.cookies.get('userId') }
+  };
+}));
+```


### PR DESCRIPTION
I was quite confused as to why graphqlKoa GraphQLConfig functions would take a request object instead of a context. Looking at the source code, turns out they don't! They in fact take ctx.